### PR TITLE
Add init_module() measurement description

### DIFF
--- a/event-log-format.rst
+++ b/event-log-format.rst
@@ -878,6 +878,8 @@ may be:
 
 * ``kernel_version`` version string
 
+* ``init_module`` hash of the buffer data loaded during init_module()
+
 .. warning::
 
    Define all n-ng field names and the meaning of the strings.

--- a/policy-syntax.rst
+++ b/policy-syntax.rst
@@ -226,20 +226,21 @@ file).
 
 Note:
 
-IMA only measures and appraises kernel modules loaded by the
-finit_module() syscall. IMA does not measure or appraise kernel
-modules loaded by the init_module() syscall.
+This only measures and appraises kernel modules loaded by the
+finit_module() syscall. Kernel modules loaded by the init_module()
+syscall can be measured with :ref:`func-critical-data`.
 
 if ``CONFIG_MODULE_SIG`` is enabled, then the init_module() syscall is
 used. An application can avoid the func=MODULE_CHECK measurement by
 calling init_module() specifying a memory buffer rather than a disk
 file. In this case, func=MODULE_CHECK is ineffective.
 
-This policy is better, but can still be bypassed.
+Adding the following policy permits to also measure kernel modules
+loaded by init_module() (see :ref:`buf-critical-data`):
 
 ::
 
-   measure func=FILE_CHECK mask=MAY_READ uid=0
+   measure func=CRITICAL_DATA label=modules
 
 
 If ``CONFIG_MODULE_SIG`` is disabled (the better choice),


### PR DESCRIPTION
Hello @kgoldman , since now it is possible to measure init_module() events [1] I propose this update.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.12-rc4&id=cc293c8466625bf8d238fc41d26db169a126e21b