### PR TITLE
ima-utilities: Fix slash for policy path

### DIFF
--- a/ima-utilities.rst
+++ b/ima-utilities.rst
@@ -754,7 +754,7 @@ To read the signature:
 
    getfattr -m - -e hex -d policy
 
-To install the policy.  The policy path must start with ``\``.
+To install the policy.  The policy path must start with ``/``.
 
 ::
 


### PR DESCRIPTION
Path on Linux uses '/' not '\'.

Fixes: d75560e ("Add to signing a custom policy")

@kgoldman FYI