### PR TITLE
ima-utilities: Fix --ca formatting

### DIFF
--- a/ima-utilities.rst
+++ b/ima-utilities.rst
@@ -355,14 +355,14 @@ View the updated keyring:
 
 .. note::
 
-   With the --ca argument, the certificate attributes are
+   With the ``--ca`` argument, the certificate attributes are
 
    ::
 
       	Digital Signature, Certificate Sign, CRL Sign
                 CA:TRUE
 
-   Without the --ca argument, the certificate attributes are
+   Without the ``--ca`` argument, the certificate attributes are
 
    ::
 


### PR DESCRIPTION
`--ca` is due `--` turned in to `–ca` (unicode ndash). Use backquotes for code formatting to prevent this conversion (+ better readability).

Fixes: 0751ad1 ("Update mokutils usage")