### PR TITLE
Various minor fixes

### DIFF
--- a/event-log-format.rst
+++ b/event-log-format.rst
@@ -140,7 +140,7 @@ For backward compatibility
 
 ``binary_runtime_measurements`` and
 ``ascii_runtime_measurements``
-are linked to 
+are linked to
 ``binary_runtime_measurements_sha1`` and
 ``ascii_runtime_measurements_sha1``
 
@@ -523,7 +523,7 @@ The length and hash algorithm are determined by the :ref:`hash-algorithm`
 field.
 
 .. _d-modsig:
-  
+
 d-modsig
 -----------------------------------
 

--- a/ima-concepts.rst
+++ b/ima-concepts.rst
@@ -319,7 +319,7 @@ to the system audit log ``/var/log/audit/audit.log``.
 
 Events that require a measure policy rule include:
 
-* integrity violations 
+* integrity violations
 * failure to extend the TPM PCR
 
 Events that require an appraise policy rule include:
@@ -523,7 +523,7 @@ for instructions.
 2. Wrap (encrypt) the ``master key`` with the TPM storage primary key.
 3. Store the wrapped ``master key`` in the filesystem.
 4. Generate an HMAC key.
-5. Encrypt the HMAC key with the ``master key`` to create the ``encrypted key`` 
+5. Encrypt the HMAC key with the ``master key`` to create the ``encrypted key``
 6. Store the ``encrypted key`` in the filesystem.
 
 If :ref:`config-user-decrypted-data` is not set, the HMAC key is

--- a/ima-configuration.rst
+++ b/ima-configuration.rst
@@ -237,7 +237,7 @@ enabled, IMA verifies (appraises) the signatures.
 
 That is, if ``CONFIG_KEXEC_SIG`` is true, the kernel will require and
 verify the signature over the kernel image.  If false,
-``CONFIG_IMA_ARCH_POLICY`` will add an IMA appraise 
+``CONFIG_IMA_ARCH_POLICY`` will add an IMA appraise
 :ref:`func-kexec-kernel-check` rule.
 
 If ``CONFIG_MODULE_SIG`` is true, the kernel will verify a kernel
@@ -421,7 +421,7 @@ signatures. :ref:`config-ima-appraise-build-policy` enables this
 flag.
 
 It requires the IMA policy to be signed and verified
-by a key on the trusted IMA keyring.See :ref:`func`, 
+by a key on the trusted IMA keyring.See :ref:`func`,
 :ref:`appraise-type`, and :ref:`custom-policy`.
 
 ::
@@ -702,7 +702,7 @@ before keys can be loaded onto :ref:`keyrings`.
 
 .. _config-load-uefi-keys:
 
-CONFIG_LOAD_UEFI_KEYS 
+CONFIG_LOAD_UEFI_KEYS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When this boolean is set, the :ref:`dot-platform` keyring is
@@ -741,8 +741,8 @@ The configuration flags affecting EVM are below:
 * :ref:`config-trusted-keys`
 * :ref:`config-evm-add-xattrs`
 * :ref:`config-evm-extra-smack-xattrs`
-  
-  
+
+
 .. _config-evm:
 
 CONFIG_EVM
@@ -899,7 +899,7 @@ Fedora 39		set
 
 .. _config-integrity-ca-machine-keyring-max:
 
-CONFIG_INTEGRITY_CA_MACHINE_KEYRING_MAX  
+CONFIG_INTEGRITY_CA_MACHINE_KEYRING_MAX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When this boolean is set, registered ``MOK`` key signing CA
@@ -1146,7 +1146,7 @@ ima_template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``ima_template=`` argument specifies boot time :ref:`ima-event-log`
-:ref:`built-in-templates`.  There are several 
+:ref:`built-in-templates`.  There are several
 :ref:`built-in-templates`. See :ref:`built-in-templates` for their
 effect.
 
@@ -1171,7 +1171,7 @@ supported values for ``ima_template=`` are:
 
 .. _ima-canonical-fmt:
 
-ima_canonical_fmt  
+ima_canonical_fmt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``ima_canonical_fmt`` option sets the canonical format for the

--- a/ima-policy.rst
+++ b/ima-policy.rst
@@ -456,13 +456,7 @@ A custom policy may specified at boot time or at runtime, or
 both. Either replaces the :ref:`built-in-policy-rules` enabled on the
 boot command line.  The policy file has one
 :ref:`policy-syntax-action` per line.  Empty lines are forbidden.
-Lines beginning with ``#`` are comments.  Use
-
-::
-
-   dmesg
-
-to check for errors.
+Lines beginning with ``#`` are comments.  Use ``dmesg`` to check for errors.
 
 If running appraisal and
 

--- a/ima-policy.rst
+++ b/ima-policy.rst
@@ -462,7 +462,7 @@ Lines beginning with ``#`` are comments.  Use
 
    dmesg
 
-to check for errors. 
+to check for errors.
 
 If running appraisal and
 
@@ -482,7 +482,7 @@ shows a signing utility.
    :ref:`func` rules except :ref:`func-file-check` come before the
    ``dont_measure`` rules so that measurements trigger even for items
    in ``tmpfs``.
- 
+
 
 .. _boot-time-custom-policy:
 

--- a/ima-utilities.rst
+++ b/ima-utilities.rst
@@ -252,7 +252,7 @@ Package:
 * Fedora - xz
 * Ubuntu - xz-utils
 
-Use the ``xy`` utility to unzip a kernel module ``.ko.xz`` to view an
+Use the ``xz`` utility to unzip a kernel module ``.ko.xz`` to view an
 appended signature.  Unzip in a /tmp directory.  See
 :ref:`func-module-check` for a use case.
 

--- a/ima-utilities.rst
+++ b/ima-utilities.rst
@@ -500,7 +500,7 @@ Generate an ECC P256 CA key and certificate:
 
 ::
 
-   openssl req -x509 -out imacacertecc.pem -newkey ec -pkeyopt ec_paramgen_curve:secp256k1 -days 3650 -keyout imacakeyecc.pem -config imacacert.cfg 
+   openssl req -x509 -out imacacertecc.pem -newkey ec -pkeyopt ec_paramgen_curve:secp256k1 -days 3650 -keyout imacakeyecc.pem -config imacacert.cfg
 
 Convert the certificate from ``pem`` to ``der`` format.
 
@@ -740,7 +740,7 @@ template.  See :ref:`sign-file-appended-signature` for an example.
 Package:
 
 * Fedora - kernel-devel
-* Ubuntu - linux-headers-\`uname -r\`-generic 
+* Ubuntu - linux-headers-\`uname -r\`-generic
 
 Location:
 

--- a/ima-utilities.rst
+++ b/ima-utilities.rst
@@ -235,7 +235,7 @@ Build the new Linux kernel.
    make localmodconfig O=../kernelbuild/linux-6.8.y
    make -j 8 O=../kernelbuild/linux-6.8.y
 
-Copy the results to ``\boot``.
+Copy the results to ``/boot``.
 
 ::
 

--- a/policy-syntax.rst
+++ b/policy-syntax.rst
@@ -949,7 +949,7 @@ Example:
 ::
 
 	measure func=BPRM_CHECK subj_type=unconfined_t
-	measure func=FILE_CHECK mask=MAY_READ subj_user=system_u 
+	measure func=FILE_CHECK mask=MAY_READ subj_user=system_u
 
 .. _subj-role-equals:
 


### PR DESCRIPTION
* ima-utilities: Fix 'xz' tool name
* ima-policy: Inline single word 'dmesg'
* tree: Remove trailing whitespace
* ima-utilities: Fix /boot
